### PR TITLE
Fix dr_util tests

### DIFF
--- a/test/bitwise.cpp
+++ b/test/bitwise.cpp
@@ -11,11 +11,11 @@ namespace dr {
 
 TEST(BitwiseTest, makeBitMask) {
 	// least significant bit
-	EXPECT_EQ(0x1,        bitMask(0));
+	EXPECT_EQ(0x1u,        bitMask(0));
 	// some middle bit
-	EXPECT_EQ(0x4000,     bitMask(14));
+	EXPECT_EQ(0x4000u,     bitMask(14));
 	// most significant bit
-	EXPECT_EQ(0x80000000, bitMask(31));
+	EXPECT_EQ(0x80000000u, bitMask(31));
 }
 
 TEST(BitwiseTest, testTestBit) {

--- a/test/tuple.cpp
+++ b/test/tuple.cpp
@@ -15,40 +15,40 @@ int main(int argc, char * * argv) {
 
 TEST(TupleTest, sliceOne) {
 	auto tuple = std::make_tuple(1, true, 3);
-	EXPECT_EQ(1,    std::tuple_size<decltype(tuple_slice<0, 1>(tuple))>::value);
-	EXPECT_EQ(1,    std::tuple_size<decltype(tuple_slice<1, 1>(tuple))>::value);
-	EXPECT_EQ(1,    std::tuple_size<decltype(tuple_slice<2, 1>(tuple))>::value);
-	EXPECT_EQ(1,    std::get<0>(tuple_slice<0, 1>(tuple)));
+	EXPECT_EQ(1u,    std::tuple_size<decltype(tuple_slice<0, 1>(tuple))>::value);
+	EXPECT_EQ(1u,    std::tuple_size<decltype(tuple_slice<1, 1>(tuple))>::value);
+	EXPECT_EQ(1u,    std::tuple_size<decltype(tuple_slice<2, 1>(tuple))>::value);
+	EXPECT_EQ(1u,    std::get<0>(tuple_slice<0, 1>(tuple)));
 	EXPECT_EQ(true, std::get<0>(tuple_slice<1, 1>(tuple)));
-	EXPECT_EQ(3,    std::get<0>(tuple_slice<2, 1>(tuple)));
+	EXPECT_EQ(3u,    std::get<0>(tuple_slice<2, 1>(tuple)));
 }
 
 TEST(TupleTest, sliceTwo) {
 	auto tuple = std::make_tuple(1, true, 3);
-	EXPECT_EQ(2, std::tuple_size<decltype(tuple_slice<0, 2>(tuple))>::value);
-	EXPECT_EQ(2, std::tuple_size<decltype(tuple_slice<1, 2>(tuple))>::value);
-	EXPECT_EQ(1,    std::get<0>(tuple_slice<0, 2>(tuple)));
+	EXPECT_EQ(2u, std::tuple_size<decltype(tuple_slice<0, 2>(tuple))>::value);
+	EXPECT_EQ(2u, std::tuple_size<decltype(tuple_slice<1, 2>(tuple))>::value);
+	EXPECT_EQ(1u,    std::get<0>(tuple_slice<0, 2>(tuple)));
 	EXPECT_EQ(true, std::get<1>(tuple_slice<0, 2>(tuple)));
 	EXPECT_EQ(true, std::get<0>(tuple_slice<1, 2>(tuple)));
-	EXPECT_EQ(3,    std::get<1>(tuple_slice<1, 2>(tuple)));
+	EXPECT_EQ(3u,    std::get<1>(tuple_slice<1, 2>(tuple)));
 }
 
 TEST(TupleTest, sliceThree) {
 	auto tuple = std::make_tuple(1, true, 3);
-	EXPECT_EQ(3, std::tuple_size<decltype(tuple_slice<0, 3>(tuple))>::value);
-	EXPECT_EQ(1,    std::get<0>(tuple_slice<0, 3>(tuple)));
+	EXPECT_EQ(3u, std::tuple_size<decltype(tuple_slice<0, 3>(tuple))>::value);
+	EXPECT_EQ(1u,    std::get<0>(tuple_slice<0, 3>(tuple)));
 	EXPECT_EQ(true, std::get<1>(tuple_slice<0, 3>(tuple)));
-	EXPECT_EQ(3,    std::get<2>(tuple_slice<0, 3>(tuple)));
+	EXPECT_EQ(3u,    std::get<2>(tuple_slice<0, 3>(tuple)));
 }
 
 TEST(TupleTest, tail) {
 	auto tuple = std::make_tuple(1, true, 3);
-	EXPECT_EQ(2,    std::tuple_size<decltype(tuple_tail(tuple))>::value);
+	EXPECT_EQ(2u,    std::tuple_size<decltype(tuple_tail(tuple))>::value);
 	EXPECT_EQ(true, std::get<0>(tuple_tail(tuple)));
-	EXPECT_EQ(3,    std::get<1>(tuple_tail(tuple)));
+	EXPECT_EQ(3u,    std::get<1>(tuple_tail(tuple)));
 }
 
 TEST(TupleTest, tailEmpty) {
 	auto tuple = std::make_tuple(1);
-	EXPECT_EQ(0, std::tuple_size<decltype(tuple_tail(tuple))>::value);
+	EXPECT_EQ(0u, std::tuple_size<decltype(tuple_tail(tuple))>::value);
 }

--- a/test/tuple.cpp
+++ b/test/tuple.cpp
@@ -18,34 +18,34 @@ TEST(TupleTest, sliceOne) {
 	EXPECT_EQ(1u,    std::tuple_size<decltype(tuple_slice<0, 1>(tuple))>::value);
 	EXPECT_EQ(1u,    std::tuple_size<decltype(tuple_slice<1, 1>(tuple))>::value);
 	EXPECT_EQ(1u,    std::tuple_size<decltype(tuple_slice<2, 1>(tuple))>::value);
-	EXPECT_EQ(1u,    std::get<0>(tuple_slice<0, 1>(tuple)));
+	EXPECT_EQ(1,    std::get<0>(tuple_slice<0, 1>(tuple)));
 	EXPECT_EQ(true, std::get<0>(tuple_slice<1, 1>(tuple)));
-	EXPECT_EQ(3u,    std::get<0>(tuple_slice<2, 1>(tuple)));
+	EXPECT_EQ(3,    std::get<0>(tuple_slice<2, 1>(tuple)));
 }
 
 TEST(TupleTest, sliceTwo) {
 	auto tuple = std::make_tuple(1, true, 3);
 	EXPECT_EQ(2u, std::tuple_size<decltype(tuple_slice<0, 2>(tuple))>::value);
 	EXPECT_EQ(2u, std::tuple_size<decltype(tuple_slice<1, 2>(tuple))>::value);
-	EXPECT_EQ(1u,    std::get<0>(tuple_slice<0, 2>(tuple)));
+	EXPECT_EQ(1,    std::get<0>(tuple_slice<0, 2>(tuple)));
 	EXPECT_EQ(true, std::get<1>(tuple_slice<0, 2>(tuple)));
 	EXPECT_EQ(true, std::get<0>(tuple_slice<1, 2>(tuple)));
-	EXPECT_EQ(3u,    std::get<1>(tuple_slice<1, 2>(tuple)));
+	EXPECT_EQ(3,    std::get<1>(tuple_slice<1, 2>(tuple)));
 }
 
 TEST(TupleTest, sliceThree) {
 	auto tuple = std::make_tuple(1, true, 3);
 	EXPECT_EQ(3u, std::tuple_size<decltype(tuple_slice<0, 3>(tuple))>::value);
-	EXPECT_EQ(1u,    std::get<0>(tuple_slice<0, 3>(tuple)));
+	EXPECT_EQ(1,    std::get<0>(tuple_slice<0, 3>(tuple)));
 	EXPECT_EQ(true, std::get<1>(tuple_slice<0, 3>(tuple)));
-	EXPECT_EQ(3u,    std::get<2>(tuple_slice<0, 3>(tuple)));
+	EXPECT_EQ(3,    std::get<2>(tuple_slice<0, 3>(tuple)));
 }
 
 TEST(TupleTest, tail) {
 	auto tuple = std::make_tuple(1, true, 3);
 	EXPECT_EQ(2u,    std::tuple_size<decltype(tuple_tail(tuple))>::value);
 	EXPECT_EQ(true, std::get<0>(tuple_tail(tuple)));
-	EXPECT_EQ(3u,    std::get<1>(tuple_tail(tuple)));
+	EXPECT_EQ(3,    std::get<1>(tuple_tail(tuple)));
 }
 
 TEST(TupleTest, tailEmpty) {


### PR DESCRIPTION
The tests did not compile because `-Werror` was set and there were some warnings-turned-errors on integer sign comparisons:

```
In file included from src/dr_util/test/tuple.cpp:5:
/usr/src/googletest/googletest/include/gtest/gtest.h:1392:11: error: comparison of integers of different signs: 'const int' and 'const unsigned long' [-Werror,-Wsign-compare]
  if (lhs == rhs) {
      ~~~ ^  ~~~
/usr/src/googletest/googletest/include/gtest/gtest.h:1421:12: note: in instantiation of function template specialization 'testing::internal::CmpHelperEQ<int, unsigned long>' requested here
    return CmpHelperEQ(lhs_expression, rhs_expression, lhs, rhs);
           ^
src/dr_util/test/tuple.cpp:18:2: note: in instantiation of function template specialization 'testing::internal::EqHelper<false>::Compare<int, unsigned long>' requested here
        EXPECT_EQ(1,    std::tuple_size<decltype(tuple_slice<0, 1>(tuple))>::value);
        ^
/usr/src/googletest/googletest/include/gtest/gtest.h:1924:63: note: expanded from macro 'EXPECT_EQ'
                      EqHelper<GTEST_IS_NULL_LITERAL_(val1)>::Compare, \
```